### PR TITLE
fix: tie rust export borrows to analysis lifetime

### DIFF
--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -14,27 +14,6 @@ pub struct merve_string {
     pub length: usize,
 }
 
-impl merve_string {
-    /// Convert to a Rust `&str` with an arbitrary lifetime.
-    ///
-    /// Returns `""` when `length` is 0 (which includes the case where `data` is null).
-    ///
-    /// # Safety
-    /// The caller must ensure that the backing data outlives `'a` and is valid UTF-8.
-    /// The `merve_string` itself is a temporary POD value; the data it points to
-    /// lives in the original source buffer or the analysis handle.
-    #[must_use]
-    pub unsafe fn as_str<'a>(&self) -> &'a str {
-        if self.length == 0 {
-            return "";
-        }
-        unsafe {
-            let slice = core::slice::from_raw_parts(self.data.cast(), self.length);
-            core::str::from_utf8_unchecked(slice)
-        }
-    }
-}
-
 /// Opaque handle to a CommonJS parse result.
 pub type merve_analysis = *mut c_void;
 


### PR DESCRIPTION
Resolves #16 .

Currently compiler can check UAF correctly :
```
Checking merve v1.1.0 (/home/baka/repos/merve/rust)
error[E0597]: `analysis` does not live long enough
 --> examples/unsound_check.rs:7:9
  |
5 |     let leaked: &str = {
  |         ------ borrow later stored here
6 |         let analysis = parse_commonjs(&src).unwrap();
  |             -------- binding `analysis` declared here
7 |         analysis.export_name(0).unwrap()
  |         ^^^^^^^^ borrowed value does not live long enough
8 |     };
  |     - `analysis` dropped here while still borrowed
For more information about this error, try `rustc --explain E0597`.
error: could not compile `merve` (example "unsound_check") due to 1 previous error
```