### PR TITLE
fix: do not read past the input length in the scan loops

### DIFF
--- a/rust/deps/merve.cpp
+++ b/rust/deps/merve.cpp
@@ -552,7 +552,7 @@ private:
   }
 
   void lineComment() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == '\n' || ch == '\r') {
         countNewline(ch);
@@ -563,9 +563,9 @@ private:
 
   void blockComment() {
     pos++;
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
-      if (ch == '*' && *(pos + 1) == '/') {
+      if (ch == '*' && pos + 1 < end && *(pos + 1) == '/') {
         pos++;
         return;
       }
@@ -574,7 +574,7 @@ private:
   }
 
   void stringLiteral(char quote) {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == quote)
         return;
@@ -583,7 +583,7 @@ private:
         ch = *++pos;
         if (ch == '\r') {
           ++line;
-          if (*(pos + 1) == '\n')
+          if (pos + 1 < end && *(pos + 1) == '\n')
             pos++;
         } else if (ch == '\n') {
           ++line;
@@ -595,7 +595,7 @@ private:
   }
 
   void regularExpression() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == '/')
         return;
@@ -611,7 +611,7 @@ private:
   }
 
   void regexCharacterClass() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == ']')
         return;
@@ -625,9 +625,9 @@ private:
   }
 
   void templateString() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
-      if (ch == '$' && *(pos + 1) == '{') {
+      if (ch == '$' && pos + 1 < end && *(pos + 1) == '{') {
         pos++;
         if (templateStackDepth >= STACK_DEPTH) {
           syntaxError(lexer_error::TEMPLATE_NEST_OVERFLOW);
@@ -805,7 +805,7 @@ private:
 
   void tryParseLiteralExports() {
     const char* revertPos = pos - 1;
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = commentWhitespace();
       const char* startPos = pos;
       if (identifier(ch)) {
@@ -1146,7 +1146,7 @@ private:
           if (ch != '{') break;
           pos++;
           ch = commentWhitespace();
-          if (ch != 'i' || *(pos + 1) != 'f') break;
+          if (ch != 'i' || pos + 1 >= end || *(pos + 1) != 'f') break;
           pos += 2;
           ch = commentWhitespace();
           if (ch != '(') break;
@@ -1168,7 +1168,7 @@ private:
             if (ch != quot) break;
             pos++;
             ch = commentWhitespace();
-            if (ch != '|' || *(pos + 1) != '|') break;
+            if (ch != '|' || pos + 1 >= end || *(pos + 1) != '|') break;
             pos += 2;
             ch = commentWhitespace();
             if (!matchesAt(pos, end, it_id)) break;
@@ -1195,7 +1195,7 @@ private:
               pos++;
             ch = commentWhitespace();
 
-            if (ch == 'i' && *(pos + 1) == 'f') {
+            if (ch == 'i' && pos + 1 < end && *(pos + 1) == 'f') {
               bool inIf = true;
               pos += 2;
               ch = commentWhitespace();
@@ -1214,7 +1214,7 @@ private:
                 if (ch == ';')
                   pos++;
                 ch = commentWhitespace();
-                if (ch == 'i' && *(pos + 1) == 'f') {
+                if (ch == 'i' && pos + 1 < end && *(pos + 1) == 'f') {
                   pos += 2;
                   ch = commentWhitespace();
                   if (ch != '(') break;
@@ -1235,7 +1235,7 @@ private:
                 ch = commentWhitespace();
                 if (!readExportsOrModuleDotExports(ch)) break;
                 ch = commentWhitespace();
-                if (ch != '&' || *(pos + 1) != '&') break;
+                if (ch != '&' || pos + 1 >= end || *(pos + 1) != '&') break;
                 pos += 2;
                 ch = commentWhitespace();
                 if (!readExportsOrModuleDotExports(ch)) break;
@@ -1288,7 +1288,7 @@ private:
             pos++;
             ch = commentWhitespace();
             if (ch == '&') {
-              if (*(pos + 1) != '&') break;
+              if (pos + 1 >= end || *(pos + 1) != '&') break;
               pos += 2;
               ch = commentWhitespace();
               if (ch != '!') break;
@@ -1609,7 +1609,7 @@ public:
       lastTokenPos = pos;  // Update lastTokenPos after shebang
     }
 
-    while (pos++ < end) {
+    while (++pos < end) {
       ch = *pos;
 
       if (ch == ' ' || (ch < 14 && ch > 8)) {
@@ -1649,7 +1649,7 @@ public:
               if (*pos == '(') {
                 openTokenTypeStack_[openTokenDepth] = '(';
                 openTokenPosStack_[openTokenDepth++] = lastTokenPos;
-                if (*(pos + 1) == 'r') {
+                if (pos + 1 < end && *(pos + 1) == 'r') {
                   pos++;
                   tryParseRequire(RequireType::ExportStar);
                 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -740,4 +740,19 @@ mod tests {
         assert_send::<Analysis<'_>>();
         assert_sync::<Analysis<'_>>();
     }
+
+    /// A `&str` is not NUL-terminated, so the byte past its end belongs to
+    /// whatever neighbors the allocation. The scan loops used to read it,
+    /// making every parse depend on adjacent heap contents; slicing a longer
+    /// buffer plants that byte deterministically instead of leaving it to
+    /// the allocator.
+    #[test]
+    fn does_not_read_past_the_input() {
+        let src = "module.exports = require('./implementation');\n";
+        let planted = format!("{src}(");
+        let analysis =
+            parse_commonjs(&planted[..src.len()]).expect("a byte past the input must not fail the parse");
+        let reexports: Vec<_> = analysis.reexports().map(|r| r.name.to_owned()).collect();
+        assert_eq!(reexports, ["./implementation"]);
+    }
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -550,7 +550,7 @@ private:
   }
 
   void lineComment() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == '\n' || ch == '\r') {
         countNewline(ch);
@@ -561,9 +561,9 @@ private:
 
   void blockComment() {
     pos++;
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
-      if (ch == '*' && *(pos + 1) == '/') {
+      if (ch == '*' && pos + 1 < end && *(pos + 1) == '/') {
         pos++;
         return;
       }
@@ -572,7 +572,7 @@ private:
   }
 
   void stringLiteral(char quote) {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == quote)
         return;
@@ -581,7 +581,7 @@ private:
         ch = *++pos;
         if (ch == '\r') {
           ++line;
-          if (*(pos + 1) == '\n')
+          if (pos + 1 < end && *(pos + 1) == '\n')
             pos++;
         } else if (ch == '\n') {
           ++line;
@@ -593,7 +593,7 @@ private:
   }
 
   void regularExpression() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == '/')
         return;
@@ -609,7 +609,7 @@ private:
   }
 
   void regexCharacterClass() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
       if (ch == ']')
         return;
@@ -623,9 +623,9 @@ private:
   }
 
   void templateString() {
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = *pos;
-      if (ch == '$' && *(pos + 1) == '{') {
+      if (ch == '$' && pos + 1 < end && *(pos + 1) == '{') {
         pos++;
         if (templateStackDepth >= STACK_DEPTH) {
           syntaxError(lexer_error::TEMPLATE_NEST_OVERFLOW);
@@ -803,7 +803,7 @@ private:
 
   void tryParseLiteralExports() {
     const char* revertPos = pos - 1;
-    while (pos++ < end) {
+    while (++pos < end) {
       char ch = commentWhitespace();
       const char* startPos = pos;
       if (identifier(ch)) {
@@ -1144,7 +1144,7 @@ private:
           if (ch != '{') break;
           pos++;
           ch = commentWhitespace();
-          if (ch != 'i' || *(pos + 1) != 'f') break;
+          if (ch != 'i' || pos + 1 >= end || *(pos + 1) != 'f') break;
           pos += 2;
           ch = commentWhitespace();
           if (ch != '(') break;
@@ -1166,7 +1166,7 @@ private:
             if (ch != quot) break;
             pos++;
             ch = commentWhitespace();
-            if (ch != '|' || *(pos + 1) != '|') break;
+            if (ch != '|' || pos + 1 >= end || *(pos + 1) != '|') break;
             pos += 2;
             ch = commentWhitespace();
             if (!matchesAt(pos, end, it_id)) break;
@@ -1193,7 +1193,7 @@ private:
               pos++;
             ch = commentWhitespace();
 
-            if (ch == 'i' && *(pos + 1) == 'f') {
+            if (ch == 'i' && pos + 1 < end && *(pos + 1) == 'f') {
               bool inIf = true;
               pos += 2;
               ch = commentWhitespace();
@@ -1212,7 +1212,7 @@ private:
                 if (ch == ';')
                   pos++;
                 ch = commentWhitespace();
-                if (ch == 'i' && *(pos + 1) == 'f') {
+                if (ch == 'i' && pos + 1 < end && *(pos + 1) == 'f') {
                   pos += 2;
                   ch = commentWhitespace();
                   if (ch != '(') break;
@@ -1233,7 +1233,7 @@ private:
                 ch = commentWhitespace();
                 if (!readExportsOrModuleDotExports(ch)) break;
                 ch = commentWhitespace();
-                if (ch != '&' || *(pos + 1) != '&') break;
+                if (ch != '&' || pos + 1 >= end || *(pos + 1) != '&') break;
                 pos += 2;
                 ch = commentWhitespace();
                 if (!readExportsOrModuleDotExports(ch)) break;
@@ -1286,7 +1286,7 @@ private:
             pos++;
             ch = commentWhitespace();
             if (ch == '&') {
-              if (*(pos + 1) != '&') break;
+              if (pos + 1 >= end || *(pos + 1) != '&') break;
               pos += 2;
               ch = commentWhitespace();
               if (ch != '!') break;
@@ -1607,7 +1607,7 @@ public:
       lastTokenPos = pos;  // Update lastTokenPos after shebang
     }
 
-    while (pos++ < end) {
+    while (++pos < end) {
       ch = *pos;
 
       if (ch == ' ' || (ch < 14 && ch > 8)) {
@@ -1647,7 +1647,7 @@ public:
               if (*pos == '(') {
                 openTokenTypeStack_[openTokenDepth] = '(';
                 openTokenPosStack_[openTokenDepth++] = lastTokenPos;
-                if (*(pos + 1) == 'r') {
+                if (pos + 1 < end && *(pos + 1) == 'r') {
                   pos++;
                   tryParseRequire(RequireType::ExportStar);
                 }

--- a/tests/c_api_tests.cpp
+++ b/tests/c_api_tests.cpp
@@ -482,3 +482,39 @@ TEST(c_api_tests, spread_reexports) {
   ASSERT_TRUE(merve_string_eq(merve_get_reexport_name(result, 1), "dep2"));
   merve_free(result);
 }
+
+// The scan loops previously tested-then-incremented (`pos++ < end`), reading
+// one byte past the input on their final iteration. A NUL-terminated literal
+// hides that; an exact-sized heap buffer puts the byte past `length` in an
+// ASan redzone, and a hostile byte planted there changes the parse result.
+TEST(c_api_tests, does_not_read_past_the_declared_length) {
+  const char* src = "module.exports = require('./implementation');\n";
+  size_t len = std::strlen(src);
+
+  // Exact-sized allocation: no sentinel. Under ASan the old loops fault here.
+  {
+    char* buf = new char[len];
+    std::memcpy(buf, src, len);
+    merve_error_loc err;
+    merve_analysis result = merve_parse_commonjs(buf, len, &err);
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(merve_is_valid(result));
+    EXPECT_EQ(merve_get_reexports_count(result), 1u);
+    merve_free(result);
+    delete[] buf;
+  }
+
+  // A '(' immediately past the declared length: the same allocation, so the
+  // read is deterministic rather than a heap lottery. The old loops consumed
+  // it and failed the parse with a paren error located one past the end.
+  {
+    std::string planted(src);
+    planted.push_back('(');
+    merve_error_loc err;
+    merve_analysis result = merve_parse_commonjs(planted.data(), len, &err);
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(merve_is_valid(result));
+    EXPECT_EQ(merve_get_reexports_count(result), 1u);
+    merve_free(result);
+  }
+}


### PR DESCRIPTION
The scan loops test-then-increment (`pos++ < end`), so the final iteration reads one byte past the declared input length, and several one-byte lookaheads (`*(pos + 1)`) can read that byte too. A NUL-terminated input hides this; callers passing exact-length buffers get a parse result that depends on whatever the adjacent allocation holds. The Rust wrapper passes `&str` data directly, so every parse through the crate is exposed.

We hit this in production tooling: the same source string parsed fine on macOS and failed on Linux with `UnexpectedParen` located at line 2, column 1 of a one-line source — one past the end — because the neighboring heap byte happened to be `(`. A failed parse silently drops every export, which surfaces to users as a missing-binding `SyntaxError` in the importing module. Deterministic repro:

```rust
let src = "module.exports = require('./implementation');\n";
let planted = format!("{src}(");
merve::parse_commonjs(&planted[..src.len()]) // Err(UnexpectedParen at 2:1) before this fix
```

The fix changes the loops to increment-then-test (`++pos < end`), which visits the same positions without the phantom read, and bounds each unguarded lookahead. The internally-guarded do-while in `commentWhitespace` is unchanged.

Under `-DMERVE_SANITIZE=ON` the new regression test faults with the old loops (exact-sized heap allocation, redzone directly past the input) and passes with the fix; a second case plants a hostile byte past the declared length so the read is deterministic without ASan. The Rust test covers the wrapper path. All existing tests pass, and `rust/deps` is regenerated from the fixed sources.